### PR TITLE
Remove :print-successes option entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Installation with OPAM
 - From the command line, run:
 
   ```
-  opam pin add z3 https://github.com/priyasrikumar/ocaml-z3.git
+  opam pin add z3 https://github.com/mdmoeller/ocaml-z3.git
   ```

--- a/lib/Smtlib.ml
+++ b/lib/Smtlib.ml
@@ -68,9 +68,6 @@ let command (solver : solver) (sexp : sexp) =
 
 let silent_command (solver : solver) (sexp : sexp) = write solver sexp
 
-let print_success_command =
-  SList [SSymbol "set-option"; SKeyword ":print-success"; SSymbol "true"]
-
 (* keep track of all solvers we spawn, so we can close our read/write
    FDs when the solvers exit *)
 let _solvers : (int * solver) list ref = ref []
@@ -127,12 +124,7 @@ let make_solver (z3_path : string) : solver =
   let solver = { stdin = out_chan; stdout = in_chan; stdout_lexbuf = Lexing.from_channel in_chan } in
   _solvers := (pid, solver) :: !_solvers;
   _names := (solver, ref StringMap.empty) :: !_names;
-  try
-    match command solver print_success_command with
-    | SSymbol "success" -> solver
-    | _ -> failwith "could not configure solver to :print-success"
-  with
-    Sys_error _ -> failwith "couldn't talk to solver, double-check path"
+  solver
 
 
 let fresh_name (solver : solver) (base : string) : sexp =

--- a/lib/Smtlib.ml
+++ b/lib/Smtlib.ml
@@ -339,7 +339,8 @@ let get_model (solver : solver) : (identifier * term) list =
       (Id x, sexp_to_term sexp) :: read_model rest
     | _ :: rest -> read_model rest in
   match command solver (SList [SSymbol "get-model"]) with
-  | SList ((*SSymbol "model" ::*)alist) -> read_model alist
+  | SList (SSymbol "model" :: alist)
+  | SList (alist) -> read_model alist
   | sexp -> failwith ("expected model, got " ^ (sexp_to_string sexp))
 
 let get_one_value (solver : solver) (e : term) : term =

--- a/lib/Smtlib.ml
+++ b/lib/Smtlib.ml
@@ -339,7 +339,7 @@ let get_model (solver : solver) : (identifier * term) list =
       (Id x, sexp_to_term sexp) :: read_model rest
     | _ :: rest -> read_model rest in
   match command solver (SList [SSymbol "get-model"]) with
-  | SList (SSymbol "model" :: alist) -> read_model alist
+  | SList ((*SSymbol "model" ::*)alist) -> read_model alist
   | sexp -> failwith ("expected model, got " ^ (sexp_to_string sexp))
 
 let get_one_value (solver : solver) (e : term) : term =

--- a/lib/Smtlib.mli
+++ b/lib/Smtlib.mli
@@ -40,6 +40,8 @@ type term =
   | App of identifier * term list
   | Let of string * term * term
 
+type model = (identifier * term) list
+
 (** Tactics to configure z3's solver strategy. *)
 type tactic =
   | Simplify
@@ -99,7 +101,12 @@ val check_sat : solver -> check_sat_result
 val check_sat_using : tactic -> solver -> check_sat_result
 
 (** [get_model solver] runs the command [(get-model)] *)
-val get_model : solver -> (identifier * term) list
+val get_model : solver -> model
+
+(** [get_all_models solver] repeatedly runs [get_model solver] and
+    invalidates the resulting model in order to get another one,
+    until UNSAT or UNKNOWN is reached. *)
+val get_all_models : solver -> model Seq.t
 
 val get_unsat_core : solver -> string list
 

--- a/lib/Smtlib.mli
+++ b/lib/Smtlib.mli
@@ -61,6 +61,9 @@ type check_sat_result =
   | Unsat
   | Unknown
 
+(** [set_option optname value] runs the command [(set-option optname value)] *)
+val set_option : solver -> string -> bool -> unit
+
 (** [declare_const solver x sort] runs the command [(declare-const x sort)] *)
 val declare_const : solver -> identifier -> sort -> unit
 
@@ -72,6 +75,9 @@ val declare_sort : solver -> identifier -> int -> unit
 
 (** [assert_ solver term] runs the command [(assert term)] *)
 val assert_ : solver -> term -> unit
+
+(** [assert_ solver term] runs the command [(assert (! term) :named name)] *)
+val assert_named : solver -> string -> term -> unit
 
 (** [assert_soft solver term ?~weight ?~id] runs the command [(assert-soft term :weight ~weight :id ~id] *)
 val assert_soft : solver -> ?weight:int -> ?id:string -> term -> unit
@@ -94,6 +100,8 @@ val check_sat_using : tactic -> solver -> check_sat_result
 
 (** [get_model solver] runs the command [(get-model)] *)
 val get_model : solver -> (identifier * term) list
+
+val get_unsat_core : solver -> string list
 
 (** [get_one_value solver e] runs the command [(get-value e)] *)
 val get_one_value : solver -> term -> term

--- a/z3.opam
+++ b/z3.opam
@@ -11,5 +11,6 @@ build: [
 depends: [
   "bignum"
   "ocaml"
+  "menhir"
   "dune" {build}
 ]


### PR DESCRIPTION
We ignore the success messages anyway--removing the option message at solver creation fixes a hang I was seeing on large examples.